### PR TITLE
Potential fix for code scanning alert no. 12077: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize ]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Creatrix-Net/yondaime-hokage/security/code-scanning/12077](https://github.com/Creatrix-Net/yondaime-hokage/security/code-scanning/12077)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the provided steps, the workflow primarily reads repository contents and does not appear to require write access. Therefore, we will set `contents: read` as the permission. If additional permissions are required in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
